### PR TITLE
update to 4.5

### DIFF
--- a/block_enrolmenttimer.php
+++ b/block_enrolmenttimer.php
@@ -59,6 +59,10 @@ class block_enrolmenttimer extends block_base {
         );
     }
 
+    private $completionpercentage;
+    private $activecountdown;
+    private $viewsoptions;
+
     /**
      * Tell Moodle we have some specializations.
      */


### PR DESCRIPTION
Hello!
A client requested the use of the block and it wasn't working in Moodle. I realised that I only needed to declare the attributes for the block to work in Moodle version 4.5. I did the insertion and now it's working correctly.

Best,
Thiago